### PR TITLE
fix: dedupe Cache-Control on /_pagefind/ assets

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -8,22 +8,22 @@
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable
 
-# Pagefind content-hashed shards (filename embeds an 8-char hash of the
-# indexed content). These are safe to lock down 1-year immutable.
-/_pagefind/fragment/*
+# Pagefind content-hashed shards (filename embeds an 8-char hash of
+# the indexed content). Safe to lock down 1-year immutable.
+#
+# Non-hashed pagefind assets (pagefind.js, pagefind-ui.js,
+# pagefind-entry.json, wasm.*.pagefind, …) deliberately have no
+# Cache-Control rule — they fall back to Cloudflare's default
+# ETag/Last-Modified revalidation, which is fine for a low-traffic
+# search widget.
+/_pagefind/fragment/*.pf_fragment
   Cache-Control: public, max-age=31536000, immutable
 
-/_pagefind/index/*
+/_pagefind/index/*.pf_index
   Cache-Control: public, max-age=31536000, immutable
 
 /_pagefind/*.pf_meta
   Cache-Control: public, max-age=31536000, immutable
-
-# Everything else under /_pagefind/ (pagefind.js, pagefind-ui.js,
-# pagefind-entry.json, wasm.*.pagefind, …) is regenerated each build
-# without a content hash. Cache briefly + let CDN revalidate.
-/_pagefind/*
-  Cache-Control: public, max-age=3600, stale-while-revalidate=86400
 
 /apple-touch-icon.png
   Cache-Control: public, max-age=604800, stale-while-revalidate=86400
@@ -35,7 +35,4 @@
   Cache-Control: public, max-age=604800, stale-while-revalidate=86400
 
 /favicon.ico
-  Cache-Control: public, max-age=604800, stale-while-revalidate=86400
-
-/posts/*.webp
   Cache-Control: public, max-age=604800, stale-while-revalidate=86400


### PR DESCRIPTION
## Summary
- Cloudflare Pages was merging two matching `_headers` rules into a single response header — every `/_pagefind/fragment/*.pf_fragment` (and friends) shipped with `Cache-Control: public, max-age=31536000, immutable, public, max-age=3600, stale-while-revalidate=86400`, which lets CDN/browsers honor whichever directive they parse first.
- Drop the `/_pagefind/*` catch-all so non-hashed pagefind assets (`pagefind.js`, `pagefind-ui.*`, `pagefind-entry.json`, `wasm.*.pagefind`, …) fall back to Cloudflare's default ETag/Last-Modified revalidation — fine for a low-traffic search widget.
- Tighten the three remaining rules to match by file extension (`*.pf_fragment`, `*.pf_index`, `*.pf_meta`) so only true content-hashed shards get the 1-year immutable. Also remove the dead `/posts/*.webp` rule — Astro emits all processed images under `/_astro/`, already covered.

## Test plan
- [ ] CI build passes (`npm run check` + `npm run build`)
- [ ] After deploy, `curl -I https://blog.lookscanned.io/_pagefind/fragment/en_<hash>.pf_fragment` returns a single `Cache-Control: public, max-age=31536000, immutable`
- [ ] `curl -I https://blog.lookscanned.io/_pagefind/pagefind.js` no longer has the duplicated header (default cache headers from Cloudflare are acceptable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)