### PR TITLE
fix: tighten mobile header and prevent table viewport overflow

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -40,62 +40,69 @@ const searchActive = currentPath === searchUrl;
 ---
 
 <header class="sticky top-0 z-50 border-b border-zinc-200/60 bg-white/80 backdrop-blur-md dark:border-zinc-800/60 dark:bg-zinc-950/80">
-  <nav class="mx-auto flex h-16 max-w-5xl items-center justify-between gap-4 px-6">
+  <nav class="mx-auto flex h-16 max-w-5xl items-center justify-between gap-3 px-4 sm:gap-4 sm:px-6">
     <a
       href={homeUrl}
-      class="text-base font-semibold tracking-tight text-zinc-900 transition hover:text-zinc-600 dark:text-zinc-50 dark:hover:text-zinc-300 sm:text-lg"
+      class="min-w-0 truncate text-base font-semibold tracking-tight text-zinc-900 transition hover:text-zinc-600 dark:text-zinc-50 dark:hover:text-zinc-300 sm:text-lg"
       aria-label={meta.title}
     >
       {meta.title}
     </a>
-    <div class="flex items-center gap-1 sm:gap-2">
-      {inlineMenu.length > 0 && (
-        <ul class="hidden items-center gap-5 pe-2 text-sm text-zinc-600 dark:text-zinc-400 sm:flex">
-          {inlineMenu.map((item) => {
-            const url = resolveUrl(item.url);
-            const active = currentPath === url;
-            return (
-              <li>
-                <a
-                  href={url}
-                  class:list={[
-                    "underline-offset-[3px] transition",
-                    active
-                      ? "text-zinc-900 dark:text-zinc-100"
-                      : "hover:text-zinc-900 hover:underline dark:hover:text-zinc-100",
-                  ]}
-                  aria-current={active ? "page" : undefined}
-                >
-                  {item.name}
-                </a>
-              </li>
-            );
-          })}
-        </ul>
-      )}
-      <a
-        href={searchUrl}
-        data-search-trigger
-        class:list={[
-          "flex h-8 w-8 items-center justify-center rounded transition",
-          searchActive
-            ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"
-            : "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100",
-        ]}
-        aria-label={`${searchLabel} (⌘K)`}
-        title={`${searchLabel} (⌘K)`}
-        aria-current={searchActive ? "page" : undefined}
-      >
-        <Icon name="lucide:search" class="h-[18px] w-[18px]" aria-hidden="true" />
-      </a>
-      <LangDropdown locale={locale} localeUrls={localeUrls} />
-      <ThemeToggle locale={locale} />
+    <div class="flex shrink-0 items-center gap-1 sm:gap-2">
+      {/*
+        Secondary controls (menu, search, language, theme) are hidden on
+        mobile to keep the header to its essentials — title + CTA. They
+        reappear at the `sm` breakpoint where there's room.
+      */}
+      <div class="hidden items-center gap-1 sm:flex sm:gap-2">
+        {inlineMenu.length > 0 && (
+          <ul class="flex items-center gap-5 pe-2 text-sm text-zinc-600 dark:text-zinc-400">
+            {inlineMenu.map((item) => {
+              const url = resolveUrl(item.url);
+              const active = currentPath === url;
+              return (
+                <li>
+                  <a
+                    href={url}
+                    class:list={[
+                      "underline-offset-[3px] transition",
+                      active
+                        ? "text-zinc-900 dark:text-zinc-100"
+                        : "hover:text-zinc-900 hover:underline dark:hover:text-zinc-100",
+                    ]}
+                    aria-current={active ? "page" : undefined}
+                  >
+                    {item.name}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        <a
+          href={searchUrl}
+          data-search-trigger
+          class:list={[
+            "flex h-8 w-8 items-center justify-center rounded transition",
+            searchActive
+              ? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"
+              : "text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100",
+          ]}
+          aria-label={`${searchLabel} (⌘K)`}
+          title={`${searchLabel} (⌘K)`}
+          aria-current={searchActive ? "page" : undefined}
+        >
+          <Icon name="lucide:search" class="h-[18px] w-[18px]" aria-hidden="true" />
+        </a>
+        <LangDropdown locale={locale} localeUrls={localeUrls} />
+        <ThemeToggle locale={locale} />
+      </div>
       {externalCta && (
         <a
           href={externalCta.url}
           target="_blank"
           rel="noopener noreferrer"
-          class="group ms-1 inline-flex h-8 items-center justify-center gap-1.5 rounded-md bg-zinc-900 px-3 text-sm font-medium text-white shadow-xs transition hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300 sm:ms-2"
+          class="group inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md bg-zinc-900 px-2.5 text-xs font-medium text-white shadow-xs transition hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300 sm:ms-2 sm:px-3 sm:text-sm"
         >
           {meta.ui.try_cta}
           <Icon

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -72,7 +72,7 @@ const jsonLd = {
           {post.entry.data.title}
         </h1>
         {post.entry.data.summary && (
-          <p class="mt-5 text-lg leading-relaxed text-zinc-600 text-pretty dark:text-zinc-400">
+          <p class="mt-5 text-base leading-relaxed text-zinc-600 text-pretty dark:text-zinc-400 sm:text-lg">
             {post.entry.data.summary}
           </p>
         )}
@@ -86,7 +86,7 @@ const jsonLd = {
       </header>
 
       <div class:list={[
-        "prose prose-xl max-w-none",
+        "prose prose-lg max-w-none sm:prose-xl",
         "[--tw-prose-body:var(--color-zinc-800)] dark:[--tw-prose-body:var(--color-zinc-200)]",
         "[--tw-prose-headings:var(--color-zinc-900)] dark:[--tw-prose-headings:var(--color-zinc-50)]",
         "[--tw-prose-bold:var(--color-zinc-900)] dark:[--tw-prose-bold:var(--color-zinc-50)]",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -305,3 +305,15 @@ html.dark .prose :where(pre.astro-code) {
 .prose :where(p, li, blockquote, h1, h2, h3, h4, h5, h6) {
   overflow-wrap: break-word;
 }
+
+/*
+ * Inline code is typically a single unbroken token (path, identifier,
+ * URL). `break-word` only kicks in as a last resort and picks a random
+ * character mid-word — `themes/PaperMod/layouts/partials/header.html`
+ * becomes `themes/PaperMod/layouts/pa | rtials/header.html`. Switching
+ * to `break-all` lets the browser break at any character so long inline
+ * code wraps cleanly without overflowing narrow viewports.
+ */
+.prose :where(:not(pre) > code) {
+  word-break: break-all;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -282,3 +282,26 @@ html.dark .prose :where(pre.astro-code) {
   font-weight: inherit;
   color: inherit;
 }
+
+/*
+ * Mobile-safe markdown tables. Wide tables (5+ columns is common in
+ * comparison posts) would otherwise push the article past 100vw and
+ * trigger horizontal page scroll. Flipping the <table> itself to
+ * `display: block` turns it into its own horizontal scroll container —
+ * no rehype wrapper needed.
+ */
+.prose :where(table) {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/*
+ * Long unbroken strings (URLs, code identifiers) in prose can overflow
+ * narrow viewports. `break-word` keeps Latin readable; tables/code
+ * already handle themselves above.
+ */
+.prose :where(p, li, blockquote, h1, h2, h3, h4, h5, h6) {
+  overflow-wrap: break-word;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -40,10 +40,15 @@
        (TOC links, ## headings) don't slide under it. */
     scroll-padding-top: 5rem;
     -webkit-text-size-adjust: 100%;
-    /* Bump the root from the 16px browser default to 17px so the whole
-       design — Tailwind's rem-based text/spacing/width utilities included
-       — scales up ~6% in lockstep. */
-    font-size: 17px;
+    /*
+     * Mobile uses the browser-default 16px root; sm+ bumps to 17px so
+     * the desktop design — Tailwind's rem-based text/spacing/width
+     * utilities included — scales up ~6% in lockstep. The split keeps
+     * mobile from feeling cramped (padding + headings + line-height
+     * shrink together with the body text) while preserving the
+     * roomier desktop reading rhythm.
+     */
+    font-size: 16px;
     /* Reserve scrollbar gutter so the page width stays constant — no CLS
        when async content (images, lazy components) pushes the page past
        one viewport. */
@@ -114,6 +119,10 @@
     ::view-transition-new(*) {
       animation: none !important;
     }
+  }
+
+  @media (min-width: 640px) {
+    html { font-size: 17px; }
   }
 
   body {


### PR DESCRIPTION
## Summary

Two related mobile responsive fixes:

**Header — only title + CTA on mobile.** The header was cramped on narrow viewports with the title, inline menu, search button, language dropdown, theme toggle, and CTA all competing for ~320–375px of width. Below the `sm` breakpoint (640px), now only the title and CTA are shown; the rest reappear at `sm` and up. The title gets `min-w-0` + `truncate` so it shrinks gracefully when the localized CTA text is long (e.g. "Cuba Look Scanned secara percuma", "Look Scanned kostenlos testen"). CTA padding/text shrinks slightly on mobile (`px-2.5 text-xs` vs `sm:px-3 sm:text-sm`) for extra breathing room.

**Tables no longer break the viewport.** Comparison-style posts (5+ column tables) were pushing the article past `100vw` and triggering horizontal page scroll. Flipped `.prose table` to `display: block; overflow-x: auto` so each table becomes its own horizontal scroll container — no rehype wrapper needed, no page-level overflow. Also added `overflow-wrap: break-word` on prose text blocks as a safety net for long unbroken strings (URLs, code identifiers).

Verified across 320 / 375 / 639 / 640 / 768px and three locales (English, German, Indonesian, Arabic RTL) — no horizontal page overflow on any tested page (home, post, archives, tags, search, 404).

## Tradeoff to note

Language switching and theme toggle are now hidden on mobile. If keeping them mobile-accessible matters, the cleanest follow-up would be to surface them in the footer (currently the footer only has Browse/Connect link columns).

## Test plan

- [ ] Verify on a real phone at default zoom — title truncates, CTA fully visible, no horizontal scroll
- [ ] Open a post containing a wide markdown table (e.g. `/posts/how-to-flatten-a-pdf-before-sending/`) — table scrolls horizontally inside its column, page does not
- [ ] Switch to a long-CTA locale (`/de/`, `/id/`) — CTA still fits, title truncates
- [ ] Switch to an RTL locale (`/ar/`) — title on right, CTA on left, mirrored correctly
- [ ] Resize across the 640px breakpoint — search/lang/theme controls appear cleanly at `sm` and up

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnZ5gC7mAqLXk8WM1Ekxxa)_