### PR TITLE
fix(tags): NFC-normalize tag slugs

### DIFF
--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -3,9 +3,15 @@
  * lowercase, keep Unicode letters/digits/marks (so `créatif`, `أمان`,
  * `pdf-ممسوح-ضوئياً` all round-trip), turn everything else into dashes,
  * collapse runs, trim ends.
+ *
+ * NFC-normalize first so the slug matches whatever Astro emits on disk —
+ * otherwise composition-exclusion codepoints like Bengali U+09DF (য়)
+ * stay as a single codepoint in `<a href>` while Astro writes the route
+ * path as the decomposed pair U+09AF U+09BC, breaking the link.
  */
 export function tagSlug(tag: string): string {
   return tag
+    .normalize("NFC")
     .toLowerCase()
     .replace(/[^\p{Letter}\p{Number}\p{Mark}_-]+/gu, "-")
     .replace(/-+/g, "-")


### PR DESCRIPTION
## Summary
- Some Bengali tag pages 404 because the post's `<a href>` and Astro's on-disk route path use different Unicode normalization for the same logical string.
- `tagSlug` previously did no normalization, so HTML hrefs kept the raw composed bytes from source markdown.
- Astro normalizes the param to NFC when materializing the route on disk. For codepoints on Unicode's [Composition Exclusion](https://unicode.org/Public/UNIDATA/CompositionExclusions.txt) list (e.g. Bengali `য়` U+09DF), NFC actually decomposes them — so the directory on disk ends up byte-different from the href, and byte-faithful filesystems (every production host) 404.
- Fix: `.normalize("NFC")` inside `tagSlug` so both sides go through the same form.

## Affected URLs today
- `/bn/tags/গোপনীয়তা/` — linked from `is-it-safe-to-use-online-pdf-tools-for-sensitive-documents` (bn)
- `/bn/tags/ডকুমেন্ট-ওয়ার্কফ্লো/` — linked from `how-to-flatten-a-pdf-before-sending` (bn)

Both contain `য়` (U+09DF). Spot-checked the other 31 locales — no other tag uses composition-exclusion codepoints today, but the fix is locale-agnostic.

## Test plan
- [ ] CI green
- [ ] After merge, follow-up linkinator PR ([#67](https://github.com/lookscanned/lookscanned-blog/pull/67)) should drop from 5 broken to 1 (the lone transient `[408]` from linkinator not retrying 408 — separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)