### PR TITLE
ci(linkinator): lower concurrency 10->3, bump retries 3->5

### DIFF
--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -1,8 +1,8 @@
 {
-  "concurrency": 10,
+  "concurrency": 3,
   "serverRoot": "dist",
   "retryErrors": true,
-  "retryErrorsCount": 3,
+  "retryErrorsCount": 5,
   "skip": [
     "^https?://(?!localhost:)",
     "^https?://localhost:1313"


### PR DESCRIPTION
## Summary

Linkinator's built-in static server returns `[408]` timeouts on ~1 random URL per ~10k-link crawl at `concurrency: 10` — observed three times in a row on [PR #69](https://github.com/lookscanned/lookscanned-blog/pull/69)'s identical commit, each retry hitting a different page (Korean tag, two Hungarian tags, a Romanian tag). Not a real broken link — the same URL passes every other run.

Lower `concurrency` from 10 to 3 to reduce server contention, and bump `retryErrorsCount` from 3 to 5 for extra resilience. Wall time roughly doubles (~10 min → ~20 min for the Check links step), which is fine for a reliable check.

## Test plan

- [ ] This PR's own CI passes (proves the check completes clean at the new settings)
- [ ] After merge, PR #69 will rebase onto this and CI should stop flaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)